### PR TITLE
Issue 7: second click issue

### DIFF
--- a/src/app/views/scan-screen/scan-screen.component.ts
+++ b/src/app/views/scan-screen/scan-screen.component.ts
@@ -267,7 +267,7 @@ export class ScanScreenComponent implements OnInit{
            // Popup appears on the extreme right
            //rotationClass = 'popup-rotate';
          }
-          event_position= { left: leftPosition + 'px', top: (event.clientY - 111) + 'px'};
+          event_position= { left: `calc(${leftPosition}px - 20%)`, top: (event.clientY - 111) + 'px'};
        }
       let direction:string ='rtl';
       this.modalService.setData({


### PR DESCRIPTION
Fixed miscalulation of margin for documentType modal

RCA:
margin-left is miscalculated. As the screen width increased, the value of  margin-left increased and due to miscalculation, dialog is getting shifted outside of screen (towards right).